### PR TITLE
Directory search fixes

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
-* Neither the name of the {organization} nor the names of its
+* Neither the name of the HPSSPy Project nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,9 +10,9 @@ Release Notes
 0.4.2 (unreleased)
 ------------------
 
-* Further fixes for mapping HTAR file names back to directories (PR `#5`_).
+* Further fixes for mapping HTAR file names back to directories (PR `#6`_).
 
-.. _`#5`: https://github.com/weaverba137/hpsspy/pull/5
+.. _`#6`: https://github.com/weaverba137/hpsspy/pull/6
 
 0.4.1 (2019-01-16)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,13 @@ Release Notes
 
 *Python 2 support will be dropped starting with this release.*
 
+0.4.2 (unreleased)
+------------------
+
+* Further fixes for mapping HTAR file names back to directories (PR `#5`_).
+
+.. _`#5`: https://github.com/weaverba137/hpsspy/pull/5
+
 0.4.1 (2019-01-16)
 ------------------
 

--- a/hpsspy/__init__.py
+++ b/hpsspy/__init__.py
@@ -23,4 +23,4 @@ class HpssOSError(HpssError):
     pass
 
 
-__version__ = '0.5.0.dev242'
+__version__ = '0.4.2.dev242'

--- a/hpsspy/scan.py
+++ b/hpsspy/scan.py
@@ -387,8 +387,11 @@ def extract_directory_name(filename):
     :class:`str`
         Name of a directory.
     """
-    prefix = os.path.dirname(filename).replace('/', '_') + '_'
+    d = os.path.dirname(filename)
     basefile = os.path.basename(filename).rsplit('.', 1)[0]  # remove .tar
+    if not d:
+        return basefile
+    prefix = d.replace('/', '_') + '_'
     try:
         i = basefile.index(prefix)
     except ValueError:

--- a/hpsspy/scan.py
+++ b/hpsspy/scan.py
@@ -395,7 +395,11 @@ def extract_directory_name(filename):
     try:
         i = basefile.index(prefix)
     except ValueError:
-        return basefile
+        try:
+            prefix = '_'.join(prefix.split('_')[1:])
+            i = basefile.index(prefix)
+        except ValueError:
+            return basefile
     return basefile[(i + len(prefix)):]
 
 

--- a/hpsspy/test/test_scan.py
+++ b/hpsspy/test/test_scan.py
@@ -240,6 +240,8 @@ class TestScan(unittest.TestCase):
         self.assertEqual(d, 'stability_dither-33022')
         d = extract_directory_name('foo/bar/batch.tar')
         self.assertEqual(d, 'batch')
+        d = extract_directory_name('batch.tar')
+        self.assertEqual(d, 'batch')
 
 
 def test_suite():

--- a/hpsspy/test/test_scan.py
+++ b/hpsspy/test/test_scan.py
@@ -238,6 +238,9 @@ class TestScan(unittest.TestCase):
                                     'protodesi_images_fpc_analysis_' +
                                     'stability_dither-33022.tar'))
         self.assertEqual(d, 'stability_dither-33022')
+        d = extract_directory_name(('buzzard/buzzard_v1.6_desicut/8/' +
+                                    'buzzard_v1.6_desicut_8_7.tar'))
+        self.assertEqual(d, '7')
         d = extract_directory_name('foo/bar/batch.tar')
         self.assertEqual(d, 'batch')
         d = extract_directory_name('batch.tar')


### PR DESCRIPTION
This PR fixes a few additional HTAR to directory name problems:

1. The HTAR file has no directory name (*e.g.* a bare `batch.tar`).
2. A long but *incomplete* directory prefix (*e.g.* `buzzard/buzzard_v1.6_desicut/8/buzzard_v1.6_desicut_8_7.tar`.  Note that it's not `buzzard_buzzard_v1.6`).
